### PR TITLE
Telescopeのpath_displayをfilename_firstに変更

### DIFF
--- a/nvim/lua/plugins/telescope.lua
+++ b/nvim/lua/plugins/telescope.lua
@@ -35,8 +35,7 @@ return {
             "--hidden", -- search hidden files
             "--glob=!.git/", -- exclude .git
           },
-          -- Path display settings
-          path_display = { "smart" }, -- Smart path truncation
+          path_display = { "filename_first" },
           -- Layout settings
           layout_config = {
             horizontal = {


### PR DESCRIPTION
## Summary
- `path_display = { "smart" }` は結果間で共通するディレクトリ接頭辞を省略するため、深いツリーでパスの前半が消えて位置が分かりにくくなる問題があった
- `filename_first` に変更し、ファイル名を先頭・省略なしのパスを後続に表示

## Test plan
- [ ] `:Fzf` / `<leader>ff` で深いパスのファイル名が先頭・後続にパス全体が表示されることを確認
- [ ] `:Rg` / `<leader>fg` でも同じ表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)