### PR TITLE
コミットを段階的に作成するルールを明文化

### DIFF
--- a/claude/instructions.md
+++ b/claude/instructions.md
@@ -14,7 +14,9 @@
 - Follow existing code style and patterns
 
 ## Commits & PRs
-- Commit at logical breakpoints
+- Commit incrementally as work progresses — never bundle multiple changes into one large commit
+- After finishing each logical unit (a fix, a refactor, a feature step), commit before starting the next
+- If a task touches multiple concerns, split into separate commits per concern
 - One logical change per commit
 - PR descriptions should be concise, clear, and in Japanese
 - Test Plan: only list essential verification steps. Omit nice-to-haves


### PR DESCRIPTION
## Why

Claude が長い作業の最後にまとめて巨大なコミットを作る挙動が続いており、レビューやロールバックがしづらかった。既存ルールの「Commit at logical breakpoints」が抽象的すぎて守られていなかったため、もっと強い言い回しに置き換える。

## Changes

- `claude/instructions.md` の `Commits & PRs` セクションを更新
  - 「作業の進行に合わせて段階的にコミットする / 1コミットに複数変更をまとめない」を明文化
  - 論理単位ごとに次の作業に進む前にコミットすることを明記
  - 関心事が複数ある場合は分割するルールを追加
