### PR TITLE
CLI ツールを Homebrew から home-manager へ移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,21 +69,21 @@ nix run home-manager/master -- switch --flake .#hinatades -b backup
 
 The flake uses `mkOutOfStoreSymlink`, so symlinks point at the live repo — edits take effect without rebuild.
 
-### 4. Install CLI tools and casks (Homebrew)
+### 4. Install remaining tools (Homebrew)
 
-The flake manages symlinks only. Install runtime tools separately:
+Most CLI tools are managed by the flake (`home.packages` in `home.nix`). Homebrew is still used for:
+
+- **Casks** (GUI apps, fonts): WezTerm, Hammerspoon, fonts
+- **Version managers**: goenv / pyenv / nodebrew / tfenv (better suited to brew than Nix)
+- **Services**: `postgresql@14`, `redis`
+- **Custom taps** not in nixpkgs: `d-kuro/tap/gwq`, `argoproj/tap/kubectl-argo-rollouts`
+- **Broken in nixpkgs**: `jp2a`
 
 ```sh
-brew install zsh zsh-autosuggestions neovim fzf ripgrep clang-format ghq gh kubectl starship d-kuro/tap/gwq
 brew install --cask wezterm hammerspoon
-brew install goenv pyenv nodebrew
+brew install goenv pyenv nodebrew tfenv
+brew install d-kuro/tap/gwq jp2a
 ```
-
-> [!NOTE]
-> `tmux` and `reattach-to-user-namespace` are optional. Install them only if you prefer tmux over WezTerm's built-in pane management:
-> ```sh
-> brew install tmux reattach-to-user-namespace
-> ```
 
 ### Adding another machine
 

--- a/home.nix
+++ b/home.nix
@@ -8,6 +8,40 @@ in
   home.homeDirectory = homeDirectory;
   home.stateVersion = "24.11";
 
+  home.packages = with pkgs; [
+    bat
+    btop
+    clang-tools
+    cosign
+    eza
+    fd
+    fish
+    fzf
+    gh
+    ghq
+    htop
+    jq
+    kubectx
+    kustomize
+    neovim
+    nkf
+    reattach-to-user-namespace
+    ripgrep
+    ruff
+    silver-searcher
+    sops
+    starship
+    tmux
+    tree
+    uv
+    vim
+    yamlfmt
+    yq
+    zsh
+    zsh-autosuggestions
+    zsh-completions
+  ];
+
   home.file = {
     ".zshrc".source = link ".zshrc";
     ".tmux.conf".source = link ".tmux.conf";


### PR DESCRIPTION
## Why

CLI ツールが `brew install ...` の長い 1 行に依存しており、新しいマシンで再現するには README の手順を上から実行する必要があった。home-manager flake は既に動いているので、CLI も宣言的に管理して `nix run home-manager/master -- switch` 一発で揃うようにしたい。

## Changes

- `home.nix` に `home.packages` を追加し、`brew leaves` から 31 個の CLI を移行
- README のインストール手順を再構成。brew 担当を「移行できない/向かないもの」だけに絞る

## Notes

brew に残す対象と理由:

- **Cask** (`wezterm`, `hammerspoon`, フォント): home-manager standalone では cask を扱えない
- **Version manager** (`goenv`, `pyenv`, `nodebrew`, `tfenv`): 言語ランタイムを切り替える性質上 brew のほうが相性が良い
- **Service** (`postgresql@14`, `redis`): macOS では brew services のほうが楽
- **Custom tap** (`d-kuro/tap/gwq`, `argoproj/tap/kubectl-argo-rollouts`): nixpkgs に存在しない
- **Broken in nixpkgs** (`jp2a`): `broken: true` 指定のため

nixpkgs と brew でパッケージ名が違うもの:

| brew | nixpkgs |
|---|---|
| `clang-format` | `clang-tools` |
| `the_silver_searcher` | `silver-searcher` |

適用後、`which rg fzf gh starship ...` が `/Users/hinatades/.nix-profile/bin/` を指すことを確認済み。
