### PR TITLE
言語ランタイム管理を mise に集約

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -25,20 +25,10 @@ eval "$(starship init zsh)"
 
 # Clangd
 export PATH="/usr/local/opt/llvm/bin:$PATH"
-# Node.js
-export PATH=$HOME/.nodebrew/current/bin:$PATH
-# Golang
-export GOENV_ROOT=$HOME/.goenv
-export PATH=$GOENV_ROOT/bin:$PATH
-GOENV_DISABLE_GOPATH=1
-eval "$(goenv init -)"
+# Language runtimes (managed by mise)
+eval "$(mise activate zsh)"
 export GOPATH=$HOME/.go
 export PATH=$GOPATH/bin:$PATH
-
-# Python
-export PYENV_ROOT="$HOME/.pyenv"
-export PATH="$PYENV_ROOT/shims:$PATH"
-eval "$(pyenv init -)"
 # Poetry
 export PATH="$HOME/.local/bin:$PATH"
 

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ The flake uses `mkOutOfStoreSymlink`, so symlinks point at the live repo — edi
 Most CLI tools are managed by the flake (`home.packages` in `home.nix`). Homebrew is still used for:
 
 - **Casks** (GUI apps, fonts): WezTerm, Hammerspoon, fonts
-- **Version managers**: goenv / pyenv / nodebrew / tfenv (better suited to brew than Nix)
 - **Services**: `postgresql@14`, `redis`
 - **Custom taps** not in nixpkgs: `d-kuro/tap/gwq`, `argoproj/tap/kubectl-argo-rollouts`
 - **Broken in nixpkgs**: `jp2a`
 
 ```sh
 brew install --cask wezterm hammerspoon
-brew install goenv pyenv nodebrew tfenv
 brew install d-kuro/tap/gwq jp2a
 ```
+
+Language runtimes (Go / Python / Node.js / Terraform) are managed by [mise](https://mise.jdx.dev/) — see `mise/config.toml`.
 
 ### Adding another machine
 
@@ -100,11 +100,13 @@ Add an entry under `homeConfigurations` in `flake.nix`:
 
 Then `nix run home-manager/master -- switch --flake .#yourname -b backup`.
 
-## Version Managers
+## Language Runtimes
 
-- **Golang**: goenv
-- **Python**: pyenv
-- **Node.js**: nodebrew
+Managed declaratively via [mise](https://mise.jdx.dev/) (`mise/config.toml` → `~/.config/mise/config.toml`):
+
+- **Golang**, **Python**, **Node.js**, **Terraform**
+
+Override per project with `mise.toml` or `.tool-versions` in the project root.
 
 ## Key Features
 

--- a/home.nix
+++ b/home.nix
@@ -23,6 +23,7 @@ in
     jq
     kubectx
     kustomize
+    mise
     neovim
     nkf
     reattach-to-user-namespace
@@ -55,6 +56,7 @@ in
     "nvim".source = link "nvim";
     "wezterm".source = link "wezterm";
     "starship.toml".source = link "starship.toml";
+    "mise/config.toml".source = link "mise/config.toml";
   };
 
   programs.home-manager.enable = true;

--- a/mise/config.toml
+++ b/mise/config.toml
@@ -1,0 +1,11 @@
+[tools]
+go = "1.25.5"
+python = "3.14.2"
+node = "25.2.1"
+terraform = "1.14.3"
+
+[settings]
+idiomatic_version_file_enable_tools = ["python"]
+
+[env]
+GOPATH = "{{env.HOME}}/.go"


### PR DESCRIPTION
## Why

言語ランタイムを `goenv` / `pyenv` / `nodebrew` / `tfenv` の 4 つで個別管理しており、shell 起動時に複数の init を読み、新マシン構築時にも各々セットアップする必要があった。版固定の方針も dotfiles に残らず、機械ごとに揃わない懸念があった。

[mise](https://mise.jdx.dev/) に集約すれば 1 つの init で済み、`mise/config.toml` を dotfiles に置くことで declarative に管理できる。

## Changes

- `home.packages` に `mise` を追加
- `mise/config.toml` を新規作成し、Go / Python / Node / Terraform のグローバル版と `GOPATH` を宣言
- `xdg.configFile` で `~/.config/mise/config.toml` に symlink
- `.zshrc`: `goenv` / `pyenv` / `nodebrew` の init を削除し `eval "$(mise activate zsh)"` に置換 (`GOPATH` 設定は残す)
- README: Version Managers セクションを mise ベースに書き直し、brew install 例から旧 4 つを削除

## Notes

ローカルでは `brew uninstall goenv pyenv nodebrew tfenv` 済み。`brew leaves` は 9 → 5 (service / custom tap / jp2a のみ)。`zsh -i -c 'go version; python --version; node -v; terraform version'` でいずれも従前と同じ版が解決されることを確認済み。
