### PR TITLE
zshrc: nix 移行後の Homebrew 残骸を整理

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -23,17 +23,12 @@ setopt hist_reduce_blanks
 # Starship prompt (oh-my-zsh simple theme replica)
 eval "$(starship init zsh)"
 
-# Clangd
-export PATH="/usr/local/opt/llvm/bin:$PATH"
 # Language runtimes (managed by mise)
 eval "$(mise activate zsh)"
 export GOPATH=$HOME/.go
 export PATH=$GOPATH/bin:$PATH
 # Poetry
 export PATH="$HOME/.local/bin:$PATH"
-
-# mysql
-export PATH="/opt/homebrew/opt/mysql-client/bin:$PATH"
 
 # Claude
 # export AWS_REGION=ap-northeast-1
@@ -213,15 +208,6 @@ alias e=exit
 #   tmux
 # fi
 export XDG_CONFIG_HOME=$HOME/.config
-export PATH="/usr/local/opt/libpq/bin:$PATH"
-
-# Google Cloud SDK
-if [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then
-  . "$HOME/google-cloud-sdk/path.zsh.inc"
-fi
-if [ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ]; then
-  . "$HOME/google-cloud-sdk/completion.zsh.inc"
-fi
 
 # LM Studio CLI
 export PATH="$PATH:$HOME/.lmstudio/bin"

--- a/.zshrc
+++ b/.zshrc
@@ -57,9 +57,9 @@ if command -v gwq &> /dev/null; then
     source <(gwq completion zsh)
 fi
 
-# zsh-autosuggestions (Homebrew version)
-if [ -f /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then
-  source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+# zsh-autosuggestions (nix home-manager)
+if [ -f "$HOME/.nix-profile/share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]; then
+  source "$HOME/.nix-profile/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
   ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=5'
 fi
 


### PR DESCRIPTION
## Why

nix への移行後、`.zshrc` に Homebrew 時代の参照が残っていた。

- `zsh-autosuggestions` を `/opt/homebrew/share/...` から source していたが、Homebrew からアンインストール済みでファイルが存在せず、コマンド履歴サジェストが動かなくなっていた
- 他にも、対応する Homebrew formula が無くなった `PATH` 追加が複数残っており、サイレントに dead path を `PATH` に積んでいた

## Changes

- `zsh-autosuggestions` の source 元を `~/.nix-profile/share/zsh-autosuggestions/zsh-autosuggestions.zsh` に変更
- 以下の存在しないディレクトリの `PATH` 追加を削除
  - `/usr/local/opt/llvm/bin` (clangd は nix の `clang-tools` で提供)
  - `/opt/homebrew/opt/mysql-client/bin` (`mysql-client` 未インストール)
  - `/usr/local/opt/libpq/bin` (`libpq` 未インストール、`psql` は brew の `postgresql@14` 経由で動作)
- `~/google-cloud-sdk/path.zsh.inc` / `completion.zsh.inc` の読み込みブロック削除 (ファイル不在、`~/Downloads/google-cloud-sdk/...` の方は実体ありなので残す)

## Notes

確認した稼働中の実体:

| ツール | 解決先 |
|---|---|
| clangd | `~/.nix-profile/bin/clangd` (nix) |
| psql | `/opt/homebrew/bin/psql` (brew `postgresql@14`) |
| fzf / starship / gh / ghq / jq | `~/.nix-profile/bin/...` (nix) |
| node / go / python | `~/.local/share/mise/installs/...` (mise) |

## Test Plan

- [ ] 新しいシェルで `echo $PATH` に `/usr/local/opt/llvm/bin` / `/opt/homebrew/opt/mysql-client/bin` / `/usr/local/opt/libpq/bin` が含まれないこと
- [ ] コマンド入力中に履歴ベースのサジェストが灰色文字で出ること
