### PR TITLE
create-pr: Changes セクションの粒度ルールを明確化

### DIFF
--- a/claude/skills/create-pr/SKILL.md
+++ b/claude/skills/create-pr/SKILL.md
@@ -27,7 +27,7 @@ Before creating a PR, check:
 Write the PR body with the following sections:
 
 1. **## Why** — Why this change is needed. Describe the problem or inconvenience that existed before.
-2. **## Changes** — What changed. Bullet points, concise.
+2. **## Changes** — What was done, at a coarse granularity. Each bullet should describe an *action and outcome* (one logical change per bullet), not a list of edited files or per-line details. Do not name specific files, directories, or paths — describe the change in terms of behavior, configuration, or intent. Several related edits across files collapse into one bullet.
 3. **## Notes** (optional) — Before/after comparisons, concrete values, or other context that helps the reviewer make a decision.
 
 ### Principles


### PR DESCRIPTION
## Why

create-pr スキルが生成する PR の Changes セクションが、ファイル名や行単位の詳細を列挙する傾向にあり、レビュー時に「結局何をやった PR なのか」が読み取りづらかった。「行動と結果」単位の粗い粒度に揃える方針をルール化する。

## Changes

- Changes セクションの記述粒度ルールを明確化し、ファイル名や個別パスを書かず行動と結果単位でまとめるよう指示

## Notes

Before / After の方針比較:

| | Before | After |
|---|---|---|
| 1 bullet の粒度 | ファイル / パス単位の変更 | 行動と結果 (1 logical change) |
| ファイル名・パス | 持ち出してよい | 書かない (振る舞い・設定で表現) |
| 関連する複数編集 | 個別に列挙 | 1 bullet に集約 |

## Test Plan

- [ ] 次に create-pr スキル経由で作る PR の Changes 欄が、ファイル名を含まず行動と結果単位の粗い bullet で構成されている
