### PR TITLE
fix(zshrc): macOS アップグレード後も nix を自動で読み込む

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,12 @@
 export PATH=/usr/local/bin:$PATH
 
+# Nix
+# macOS upgrades overwrite /etc/zshrc and drop the nix-daemon block,
+# so source it here to survive OS updates.
+if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+  . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+fi
+
 # Zsh History Configuration
 # History file location (synced via Dropbox)
 HISTFILE=$HOME/.zsh_history


### PR DESCRIPTION
## Why

macOS のバージョンアップ時、システムが `/etc/zshrc` を上書きするため、nix インストーラが追記していた nix-daemon の読み込みブロックが消えてしまう。その結果、アップグレードのたびに手動で `. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh` を実行しないと wezterm の zsh で nix が使えなくなっていた。

## Changes

- ユーザーの zsh 設定で nix-daemon を読み込むようにし、OS アップグレード後も手動 source なしで nix が利用できるようにした

## Notes

- `~/.zshrc` は home-manager の out-of-store symlink でこのリポジトリの設定を直接参照しているため、編集は即時反映される（`home-manager switch` 不要）。
- macOS が上書きするのは `/etc/zshrc`（システム側）のみで、ユーザー設定には影響しないため、ユーザー側に source を持たせることで恒久対応になる。
- 確認: 新規ログイン zsh で `nix` が `/nix/var/nix/profiles/default/bin` から解決できることを確認済み。
