### PR TITLE
feat(wezterm): リーダー + x でペインを確認なしに即座に閉じる

### DIFF
--- a/wezterm/keybinds.lua
+++ b/wezterm/keybinds.lua
@@ -218,8 +218,8 @@ return {
 		-- Pane作成
 		{ key = "|", mods = "LEADER|SHIFT", action = act.SplitHorizontal({ domain = "CurrentPaneDomain" }) },
 		{ key = "-", mods = "LEADER", action = act.SplitVertical({ domain = "CurrentPaneDomain" }) },
-		-- Paneを閉じる leader + x
-		{ key = "x", mods = "LEADER", action = act({ CloseCurrentPane = { confirm = true } }) },
+		-- Paneを閉じる leader + x（確認なしで即座に破棄）
+		{ key = "x", mods = "LEADER", action = act({ CloseCurrentPane = { confirm = false } }) },
 		-- Pane移動 vim風
 		{ key = "h", mods = "LEADER", action = act.ActivatePaneDirection("Left") },
 		{ key = "l", mods = "LEADER", action = act.ActivatePaneDirection("Right") },


### PR DESCRIPTION
## Why

ペインを閉じる際に毎回確認ダイアログが表示され、素早く破棄できなかった。

## Changes

- リーダー + x でペインを確認なしに即座に閉じるようにした。WezTerm のペインはバックエンドに永続化されないため、プロセスごと完全に破棄される。

## Notes

- Before: `CloseCurrentPane { confirm = true }`（確認ダイアログあり）
- After: `CloseCurrentPane { confirm = false }`（即破棄）
